### PR TITLE
getMembers now works.

### DIFF
--- a/src/Metal/MatrixAPI/LowLevel/GetRoomInformation.hs
+++ b/src/Metal/MatrixAPI/LowLevel/GetRoomInformation.hs
@@ -99,15 +99,7 @@ getMembers :: Room
            -- ^ The authorisation information which is used to fetch
            -- the list of members
            -> IO (Either Stringth Room);
-getMembers room a = pure $ Right room -- process <.> rq room "/members"
-  -- \^ This hack is grody.
-  --
-  -- This hack is created when @getMembers@ is broken such that
-  -- @getMembers@'s HTTP request always returns a 404 error and
-  -- @getMembers@ _always_ returns 'Left' values; as a result of this
-  -- brokenness, @getMembers@ is currently damn near useless.
-  --
-  -- A fix should be created... eventually.
+getMembers room = process <.> rq room "/members"
   where
   process :: Response BS.ByteString -> Either Stringth Room
   process response = case getResponseStatusCode response of
@@ -182,4 +174,4 @@ rq :: Room
 rq room k = TP.req TP.GET [] querr ""
   where
   querr :: String
-  querr = "/matrix/_client/r0/rooms/" ++ roomId room ++ k;
+  querr = "_matrix/client/r0/rooms/" ++ roomId room ++ k;


### PR DESCRIPTION
In short, before this commit is made, rq is broken such that rq sends malformed paths.

Sayonara, grody hack!