### PR TITLE
getRoomInformation now supports rooms which lack topics and display names.

### DIFF
--- a/app/matelcli.hs
+++ b/app/matelcli.hs
@@ -354,7 +354,7 @@ createRoom' [_,_] = error "Should I just assume that you want to make \
 createRoom' (nm:tpc:pbl:_) = createRoom rm pbl >=> display
   where
   rm :: Room
-  rm = Def.room {roomName = T.pack nm, topic = T.pack tpc}
+  rm = Def.room {roomName = Just $ T.pack nm, topic = Just $ T.pack tpc}
   --
   display :: Either String Room -> IO ()
   display = either error (putStrLn . roomId);

--- a/src/Metal/Default.hs
+++ b/src/Metal/Default.hs
@@ -53,9 +53,9 @@ room :: Room;
 room = Room {
   roomId = "UNDEFINED!!!  I MAY BE AN ERROR!!!",
   roomHumanId = "UNDEFINED!!!  I MAY BE AN ERROR!!!",
-  roomName = "UNDEFINED!!!  I MAY BE AN ERROR!!!",
+  roomName = Nothing,
   members = [user],
-  topic = "UNDEFINED!!!  I MAY BE AN ERROR!!!",
+  topic = Nothing,
   isEncrypted = False,
   publicKey = Nothing
 };

--- a/src/Metal/MatrixAPI/LowLevel/GetRoomInformation.hs
+++ b/src/Metal/MatrixAPI/LowLevel/GetRoomInformation.hs
@@ -126,15 +126,10 @@ getTopic :: Room
 getTopic r = process <.> rq r "/state/m.room.topic/"
   where
   process :: Response BS.ByteString -> Room
-  process k = Def.room {topic = fromMaybe kemo $ extractTopic k}
+  process k = Def.room {topic = extractTopic k}
   --
   extractTopic :: Response BS.ByteString -> Maybe T.Text
-  extractTopic k = getResponseBody k ^? A.key "name" . A._String
-  --
-  kemo :: T.Text
-  kemo = error $ "A fairly goofy error is encountered.  The JSON " ++
-         "value which the \"m.room.topic\" request returns does " ++
-         "NOT contain a \"name\" field.";
+  extractTopic k = getResponseBody k ^? A.key "name" . A._String;
 
 -- | @getRoomName r a@ fetches the display name of the Matrix room whose
 -- room ID is @roomId r@.  The @'roomName'@ value of the output 'Room'
@@ -151,15 +146,10 @@ getRoomName :: Room
 getRoomName r = process <.> rq r "/state/m.room.name/"
   where
   process :: Response BS.ByteString -> Room
-  process k = Def.room {roomName = fromMaybe kemo $ extractName k}
+  process k = Def.room {roomName = extractName k}
   --
   extractName :: Response BS.ByteString -> Maybe T.Text
-  extractName k = getResponseBody k ^? A.key "name" . A._String
-  --
-  kemo :: T.Text
-  kemo = error "A fairly goofy error is encountered.  The \
-               \\"m.room.name\" request returns a JSON value which \
-               \does NOT contain a \"name\" field.";
+  extractName k = getResponseBody k ^? A.key "name" . A._String;
 
 -- | @rq room k a@ is the response to the authorised HTTP request
 -- "GET https:\/\/[@homeserver a@]\/\_matrix\/client\/v3\/rooms\

--- a/src/Metal/Room.hs
+++ b/src/Metal/Room.hs
@@ -19,14 +19,17 @@ data Room = Room {
   -- | @roomHumanId k@ is the "human-readable" identifier of @k@, e.g.,
   -- "#johnnykissassSuckupfest:matrix.org".
   roomHumanId :: Identifier,
-  -- | @roomName k@ is the display name of @k@, e.g., "Johnny Kissass's
+  -- | If @k@ has a display name, then @roomName k@ is 'Just' the
+  -- display name of @k@, e.g., "Johhny Kissass's Suck-Up Fest".
+  -- @roomName k@ is otherwise 'Nothing'.
   -- Suck-Up Fest".
-  roomName :: Stringth,
+  roomName :: Maybe Stringth,
   -- | @members k@ is a list of the members of @k@.  Matel does not
   -- sort members according to any particular thing.
   members :: [User],
-  -- | @topic k@ equals the topic of @k@.
-  topic :: Stringth,
+  -- | If @k@ has a topic, then @topic k@ 'Just' equals the topic of
+  -- @k@.  @topic k@ is otherwise 'Nothing'.
+  topic :: Maybe Stringth,
   -- | @isEncrypted k@ iff encryption is enabled within @k@.
   isEncrypted :: Bool,
   -- | @publicKey k@ equals the public key of @k@.  If @k@ is


### PR DESCRIPTION
The Room datatype's topic-and-display-name-related fields are now Maybe-monadic.  getRoomInformation now supports rooms which lack display names and topics.

Before this change is made, getRoomInformation breaks when users of getRoomInformation attempt to fetch the display names of rooms which lack display names.  This change fixes this error.