### PR TITLE
The redundant "isEncrypted" is junked.

### DIFF
--- a/src/Metal/Default.hs
+++ b/src/Metal/Default.hs
@@ -56,7 +56,6 @@ room = Room {
   roomName = Nothing,
   members = [user],
   topic = Nothing,
-  isEncrypted = False,
   publicKey = Nothing
 };
 

--- a/src/Metal/MatrixAPI/HighLevel.hs
+++ b/src/Metal/MatrixAPI/HighLevel.hs
@@ -53,6 +53,7 @@ module Metal.MatrixAPI.HighLevel (
   markRead,
 ) where
 import Data.Bool;
+import Data.Maybe;
 import Metal.Auth;
 import Metal.Base;
 import Metal.Room;
@@ -221,7 +222,7 @@ send event italy a = maybeEncrypt >>= either blowUp jstdt
   maybeEncrypt :: IO (Either Stringth (Either StdMess Encrypted))
   maybeEncrypt = getRoomInformation italy a >>= either (return . Left) (Right <.> process)
   blowUp = return . Just . T.unpack
-  process dullards = if isEncrypted dullards
+  process dullards = if isNothing (publicKey dullards)
                        -- \| These dullards can AT LEAST use
                        -- encryption... allegedly.
                        then Right <$> roomEncrypt event dullards

--- a/src/Metal/MatrixAPI/LowLevel/RecordCombination.hs
+++ b/src/Metal/MatrixAPI/LowLevel/RecordCombination.hs
@@ -86,7 +86,6 @@ instance Combinable Room where
     roomName = g roomName,
     members = g members,
     topic = g topic,
-    isEncrypted = g isEncrypted,
     publicKey = g publicKey
   } where
     g :: Eq b => (Room -> b) -> b

--- a/src/Metal/Room.hs
+++ b/src/Metal/Room.hs
@@ -32,8 +32,6 @@ data Room = Room {
   -- | If @l@ has a topic, then @topic k@ 'Just' equals the topic of
   -- @l@.  @topic k@ is otherwise 'Nothing'.
   topic :: Maybe Stringth,
-  -- | @isEncrypted k@ iff encryption is enabled within @l@.
-  isEncrypted :: Bool,
   -- | If @l@ is encrypted, then @publicKey k@ 'Just' equals the public
   -- key of @l@.  @publicKey k@ is otherwise 'Nothing'.
   publicKey :: Maybe PublicKey


### PR DESCRIPTION
For all Room `k`, `k` represents an encrypted Matrix room iff `isJust $ publicKey k`.

Additionally, a bug is fixed.  As a result of this change, HighLevel.send now actually refuses to send unencrypted messages to rooms whose messages should be encrypted.