### PR TITLE
Encrypted is now a submodule of Messages.

### DIFF
--- a/matel.cabal
+++ b/matel.cabal
@@ -35,7 +35,7 @@ library
     Metal.OftenUsedFunctions
     Metal.MatrixAPI.HighLevel
     Metal.MatrixAPI.LowLevel
-    Metal.Encrypted
+    Metal.Messages.Encrypted
     Metal.Messages.Standard
     Metal.Messages.EncryptedFile
     Metal.Messages.FileInfo

--- a/src/Metal/Default.hs
+++ b/src/Metal/Default.hs
@@ -19,7 +19,7 @@ import Metal.Space;
 import Metal.Community;
 import Metal.Messages.Standard;
 import Metal.EventCommonFields;
-import qualified Metal.Encrypted as E;
+import qualified Metal.Messages.Encrypted as E;
 import qualified Metal.Messages.FileInfo as FI;
 import qualified Metal.Messages.EncryptedFile as EF;
 

--- a/src/Metal/MatrixAPI/HighLevel.hs
+++ b/src/Metal/MatrixAPI/HighLevel.hs
@@ -61,7 +61,7 @@ import Metal.Room;
 import Metal.Space;
 import Control.Monad;
 import Metal.Community;
-import Metal.Encrypted;
+import Metal.Messages.Encrypted;
 import Data.Either as EE;
 import Metal.EventCommonFields;
 import Metal.MatrixAPI.LowLevel;

--- a/src/Metal/MatrixAPI/LowLevel.hs
+++ b/src/Metal/MatrixAPI/LowLevel.hs
@@ -70,7 +70,7 @@ import Metal.User;
 import Data.Maybe;
 import Metal.Space;
 import Metal.Community;
-import Metal.Encrypted;
+import Metal.Messages.Encrypted;
 import Network.HTTP.Simple;
 import Metal.Messages.Standard;
 import Metal.OftenUsedFunctions;

--- a/src/Metal/MatrixAPI/LowLevel/Crypto.hs
+++ b/src/Metal/MatrixAPI/LowLevel/Crypto.hs
@@ -12,7 +12,7 @@
 -- crap.
 module Metal.MatrixAPI.LowLevel.Crypto (CryptoThing(..)) where
 import Metal.Base;
-import Metal.Encrypted;
+import Metal.Messages.Encrypted;
 import Metal.Messages.Standard;
 import Metal.OftenUsedFunctions;
 

--- a/src/Metal/MatrixAPI/LowLevel/FetchEvents.hs
+++ b/src/Metal/MatrixAPI/LowLevel/FetchEvents.hs
@@ -16,7 +16,7 @@ import Metal.Auth;
 import Metal.Base;
 import Metal.Room;
 import Metal.User;
-import Metal.Encrypted;
+import Metal.Messages.Encrypted;
 import Data.Aeson.Quick;
 import Network.HTTP.Simple;
 import Metal.Messages.FileInfo;

--- a/src/Metal/MatrixAPI/LowLevel/RecordCombination.hs
+++ b/src/Metal/MatrixAPI/LowLevel/RecordCombination.hs
@@ -16,7 +16,7 @@ import Metal.User;
 import Metal.Space;
 import Control.Monad;
 import Metal.Community;
-import Metal.Encrypted as En;
+import Metal.Messages.Encrypted as En;
 import Metal.EventCommonFields;
 import Metal.Messages.FileInfo;
 import Metal.Messages.Standard as S;

--- a/src/Metal/Messages/Encrypted.hs
+++ b/src/Metal/Messages/Encrypted.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Module    : Metal.Encrypted
+-- | Module    : Metal.Messages.Encrypted
 -- Description : Metal's datatype what represents encrypted events
 --               of the Matrix instant messaging service
 -- Copyright   : (c) Varik Valefor, 2021
@@ -11,7 +11,7 @@
 --
 -- Metal.Messages.Encrypted contains the source code of the
 -- 'Encrypted' record type.
-module Metal.Encrypted where
+module Metal.Messages.Encrypted where
 import Data.Aeson;
 import Data.Maybe;
 import Metal.Base;


### PR DESCRIPTION
Somewhat amusingly, the documentation of Metal.Encrypted indicates that Metal.Encrypted SHOULD be Metal.Messages.Encrypted.  This change may be inevitable.