### PR TITLE
The arguments of LowLevel.decrypt are re-ordered.

### DIFF
--- a/src/Metal/MatrixAPI/HighLevel.hs
+++ b/src/Metal/MatrixAPI/HighLevel.hs
@@ -154,7 +154,7 @@ fetchMessages n dir r a = liftM2 combin8 grabUnencrypted grabDecrypted
   grabUnencrypted = fetchEvents n dir r a
   --
   grabDecrypted :: IO (Either ErrorCode [StdMess])
-  grabDecrypted = fmap (>>= dl . map (decrypt a)) grabEncrypted
+  grabDecrypted = fmap (>>= dl . map (`decrypt` a)) grabEncrypted
   --
   grabEncrypted :: IO (Either ErrorCode [Encrypted])
   grabEncrypted = fetchEvents n dir r a

--- a/src/Metal/MatrixAPI/LowLevel.hs
+++ b/src/Metal/MatrixAPI/LowLevel.hs
@@ -597,11 +597,11 @@ sendEvent ev rm a = qenerateQuery >>= sendQuery
 -- Keep looking.  @decrypt@ just selects and runs an appropriate
 -- decryption function; "true" decryption logic is /not/ contained
 -- within the definition of @decrypt@.
-decrypt :: Auth
+decrypt :: Encrypted
+        -- ^ This record is the message which is to be decrypted.
+        -> Auth
         -- ^ This value contains the authorisation information of the
         -- user for whom the input message is encrypted.
-        -> Encrypted
-        -- ^ This record is the message which is to be decrypted.
         -> Either ErrorCode StdMess;
 decrypt _ _ = Left "decrypt is unimplemented.";
 


### PR DESCRIPTION
This change increases consistency.