### PR TITLE
StrictData is now a globally-used extension. 

### DIFF
--- a/matel.cabal
+++ b/matel.cabal
@@ -54,6 +54,8 @@ library
     Metal.MatrixAPI.LowLevel.RecordCombination
     Metal.MatrixAPI.LowLevel.FetchEvents
     Metal.MatrixAPI.LowLevel.HTTP
+  default-extensions:
+    StrictData
   other-extensions:
     OverloadedStrings
     TemplateHaskell


### PR DESCRIPTION
This change should kick some potential performance problems in the 'nads.