### PR TITLE
The "Protocol" datatype is added and used.

### DIFF
--- a/app/GetAuth.hs
+++ b/app/GetAuth.hs
@@ -16,6 +16,7 @@
 -- @getAuthorisationDetails@ is moved to this file to ensure that the
 -- complexity of Metal is minimised.
 module GetAuth (getAuthorisationDetails, configFilePath) where
+import Data.Char;
 import Data.Maybe;
 import Metal.Auth;
 import Metal.Base;
@@ -58,7 +59,7 @@ getAuthorisationDetails = fmap cfgToUser $ T.readFile =<< configFilePath
     password = bim "password" $ xOf "password" cfg,
     homeserver = bim "homeserver" $ T.unpack <$> xOf "homeserver" cfg,
     authToken = fromMaybe "whatever" $ T.unpack <$> xOf "authtoken" cfg,
-    protocol = T.unpack <$> xOf "protocol" cfg
+    protocol = read . map toUpper . T.unpack <$> xOf "protocol" cfg
   };
 
 -- | @configFilePath@ is the path of Matel's configuration file.

--- a/src/Metal/Base.hs
+++ b/src/Metal/Base.hs
@@ -30,7 +30,8 @@ module Metal.Base (
   ErrorCode,
   -- * High-Level Datatypes
   AlGoreRhythm (..),
-  MessageFmt (..)
+  MessageFmt (..),
+  Protocol (..)
 ) where
 import qualified Data.Text as T;
 
@@ -100,6 +101,16 @@ type ErrorCode = T.Text;
 data AlGoreRhythm = Olm
                   | Megolm
                   deriving (Eq);
+
+-- | For all 'Protocol' @k@, @k@ represents a protocol which can be used
+-- by a Matrix client for the purpose of communicating with a Matrix
+-- homeserver.
+data Protocol = HTTP
+              -- ^ 'HTTP' represents the Hypertext Transfer Protocol.
+              | HTTPS
+              -- ^ 'HTTPS' represents the Hypertext Transfer Protocol
+              -- Secure.
+              deriving (Eq, Read, Show);
 
 -- | For all 'MessageFmt' @x@, @x@ is a message type, as defined by the
 -- Matrix client-server specification.

--- a/src/Metal/MatrixAPI/LowLevel/HTTP.hs
+++ b/src/Metal/MatrixAPI/LowLevel/HTTP.hs
@@ -68,7 +68,7 @@ req type_ headers query body auth = genRequest >>= httpBS
   prefix = type_' ++ prot' ++ "://" ++ homeserver auth ++ "/"
     where
     type_' = show type_ ++ " "
-    prot' = fromJust (protocol auth);
+    prot' = show $ fromJust $ protocol auth;
 
 instance Show ReqType where
   show k = case k of

--- a/src/Metal/User.hs
+++ b/src/Metal/User.hs
@@ -35,12 +35,10 @@ data User = User {
   -- | @protocol k@, if present, describes the protocol which @l@ uses
   -- to connect to the Matrix homeserver of @l@.
   --
-  -- The standard values are "http" and "https".
-  --
   -- This value is only officially used to determine the protocol which
   -- Metal should use to contact the homeserver.  However, other uses of
   -- this thing may be possible.
-  protocol :: Maybe String,
+  protocol :: Maybe Protocol,
   -- | @keyring k@ 'Just' contains the private keys which @k@ has
   -- generated... or is 'Nothing'.
   --


### PR DESCRIPTION
The use of this datatype ensures that `User` records cannot contain bogus protocol information and prevents some potential 'splosions.